### PR TITLE
Sga 99 step tracking based on user permissions

### DIFF
--- a/app/src/main/java/com/github/k409/fitflow/model/DailyStepRecord.kt
+++ b/app/src/main/java/com/github/k409/fitflow/model/DailyStepRecord.kt
@@ -2,6 +2,7 @@ package com.github.k409.fitflow.model
 
 data class DailyStepRecord(
     var totalSteps: Long = 0,
+    var stepCounterSteps: Long = 0,
     var initialSteps: Long = 0,
     var recordDate: String = "",
     var stepsBeforeReboot: Long = 0,

--- a/app/src/main/java/com/github/k409/fitflow/ui/screen/goals/GoalsPage.kt
+++ b/app/src/main/java/com/github/k409/fitflow/ui/screen/goals/GoalsPage.kt
@@ -94,7 +94,7 @@ fun GoalsPage(
             LazyColumn(
                 modifier = Modifier
                     .matchParentSize()
-                    .padding(end = 16.dp, bottom = 16.dp),
+                    .padding(bottom = 16.dp),
                 verticalArrangement = Arrangement.Top,
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
@@ -167,7 +167,7 @@ private fun GoalCard(
     OutlinedCard(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(end = 15.dp, start = 10.dp, bottom = 10.dp, top = 10.dp),
+            .padding(16.dp),
         shape = RoundedCornerShape(6.dp),
     ) {
         Column(

--- a/app/src/main/java/com/github/k409/fitflow/ui/screen/goals/GoalsPage.kt
+++ b/app/src/main/java/com/github/k409/fitflow/ui/screen/goals/GoalsPage.kt
@@ -69,8 +69,12 @@ fun GoalsPage(
     val permissionContract = PermissionController.createRequestPermissionResultContract()
     val launcher = rememberLauncherForActivityResult(permissionContract) {
         coroutineScope.launch {
-            goalsViewModel.loadGoals(daily)
-            goalsViewModel.loadGoals(weekly)
+            if (goalsViewModel.permissionsGranted()) {
+                goalsViewModel.loadGoals(daily)
+                goalsViewModel.loadGoals(weekly)
+            } else {
+                navController.navigate(NavRoutes.Aquarium.route)
+            }
         }
     }
 


### PR DESCRIPTION
Changed step tracking logic based on user permissions.

If user refuses to accept all health connect permissions:
- and he tries to access goal screen - he is navigated to aquarium
- and he tries to access activity screen - stepCounter value is shown

if users accepts all health connect permissions:
- and he accesses goal screen - all goals are shown with health connect values
- and he accesses activity screen - health connect steps value is shown

both health connect and stepCounter values are saved into firebase.