### PR TITLE
Add dynamic Aquarium backgrounds

### DIFF
--- a/app/src/main/java/com/github/k409/fitflow/ui/screen/aquarium/component/Aquarium.kt
+++ b/app/src/main/java/com/github/k409/fitflow/ui/screen/aquarium/component/Aquarium.kt
@@ -72,14 +72,14 @@ fun AquariumContent(
 
     // at the start of each minute check what background to use
     LaunchedEffect(Unit) {
-        while(isActive) {
+        while (isActive) {
             when (LocalTime.now().format(DateTimeFormatter.ofPattern("HH:mm"))) {
                 in "00:00".."06:59" -> aquariumBackground = NightBackground
                 in "07:00".."11:59" -> aquariumBackground = MorningBackground
-                in "12:00".."17:59" ->  aquariumBackground = AfternoonBackground
+                in "12:00".."17:59" -> aquariumBackground = AfternoonBackground
                 in "18:00".."23:59" -> aquariumBackground = EveningBackground
             }
-            delay((60000 - LocalTime.now().second*1000).toLong())
+            delay((60000 - LocalTime.now().second * 1000).toLong())
         }
     }
 

--- a/app/src/main/java/com/github/k409/fitflow/ui/screen/aquarium/component/Aquarium.kt
+++ b/app/src/main/java/com/github/k409/fitflow/ui/screen/aquarium/component/Aquarium.kt
@@ -76,8 +76,9 @@ fun AquariumContent(
             when (LocalTime.now().format(DateTimeFormatter.ofPattern("HH:mm"))) {
                 in "00:00".."06:59" -> aquariumBackground = NightBackground
                 in "07:00".."11:59" -> aquariumBackground = MorningBackground
-                in "12:00".."17:59" -> aquariumBackground = AfternoonBackground
-                in "18:00".."23:59" -> aquariumBackground = EveningBackground
+                in "12:00".."16:59" -> aquariumBackground = AfternoonBackground
+                in "17:00".."21:59" -> aquariumBackground = EveningBackground
+                in "22:00".."23:59" -> aquariumBackground = NightBackground
             }
             delay((60000 - LocalTime.now().second * 1000).toLong())
         }

--- a/app/src/main/java/com/github/k409/fitflow/ui/screen/aquarium/component/AquariumTokens.kt
+++ b/app/src/main/java/com/github/k409/fitflow/ui/screen/aquarium/component/AquariumTokens.kt
@@ -7,21 +7,29 @@ import androidx.compose.ui.unit.dp
 
 internal object AquariumTokens {
     val MorningBackground = Brush.linearGradient(
-        colors = listOf(Color(255, 252, 0),
-            Color(255,255,255),),
+        colors = listOf(
+            Color(255, 252, 0),
+            Color(255, 255, 255),
+        ),
     )
     val AfternoonBackground = Brush.linearGradient(
-        colors = listOf(Color(67, 198, 172),
-            Color(248, 255, 174),),
+        colors = listOf(
+            Color(67, 198, 172),
+            Color(248, 255, 174),
+        ),
     )
     val EveningBackground = Brush.linearGradient(
-        colors = listOf(Color(0, 90, 167),
-            Color(255, 253, 228),),
+        colors = listOf(
+            Color(0, 90, 167),
+            Color(255, 253, 228),
+        ),
     )
     val NightBackground = Brush.linearGradient(
-        colors = listOf(Color(15, 32, 39),
+        colors = listOf(
+            Color(15, 32, 39),
             Color(32, 58, 67),
-            Color(44, 83, 100)),
+            Color(44, 83, 100),
+        ),
     )
     val MinFishSize = 100.dp
     val MaxFishSize = 150.dp

--- a/app/src/main/java/com/github/k409/fitflow/ui/screen/aquarium/component/AquariumTokens.kt
+++ b/app/src/main/java/com/github/k409/fitflow/ui/screen/aquarium/component/AquariumTokens.kt
@@ -6,8 +6,22 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 internal object AquariumTokens {
-    val AquariumBackground = Brush.linearGradient(
-        colors = listOf(Color(0xFFA7B9D3), Color(0xFF9CED96), Color(0xffd0e7cf)),
+    val MorningBackground = Brush.linearGradient(
+        colors = listOf(Color(255, 252, 0),
+            Color(255,255,255),),
+    )
+    val AfternoonBackground = Brush.linearGradient(
+        colors = listOf(Color(67, 198, 172),
+            Color(248, 255, 174),),
+    )
+    val EveningBackground = Brush.linearGradient(
+        colors = listOf(Color(0, 90, 167),
+            Color(255, 253, 228),),
+    )
+    val NightBackground = Brush.linearGradient(
+        colors = listOf(Color(15, 32, 39),
+            Color(32, 58, 67),
+            Color(44, 83, 100)),
     )
     val MinFishSize = 100.dp
     val MaxFishSize = 150.dp


### PR DESCRIPTION
## Summary of the Pull Request

Implemented dynamic Aquarium background

## PR Checklist

- Aquarium background changes for morning, afternoon, evening and night
- Change can be observed while being in Aquarium screen

## Detailed Description of the Pull Request / Additional comments

Morning:
<img src="https://github.com/PVP-K409/fit-flow/assets/127019248/2df01e04-6a0c-4172-87c4-1fccddc5a6cd" width="500" height="500">
Afternoon:
<img src="https://github.com/PVP-K409/fit-flow/assets/127019248/91cf86ae-ed6e-42a1-9541-208a6e11c41b" width="500" height="500">
Evening:
<img src="https://github.com/PVP-K409/fit-flow/assets/127019248/06293846-49db-4d8a-813d-2dd603a7e651" width="500" height="500">
Night:
<img src="https://github.com/PVP-K409/fit-flow/assets/127019248/d829ce62-032a-4871-82cf-5394c24a62e7" width="500" height="500">
