### PR TITLE
Sga 108 level based rewards

### DIFF
--- a/app/src/main/java/com/github/k409/fitflow/data/ItemRepository.kt
+++ b/app/src/main/java/com/github/k409/fitflow/data/ItemRepository.kt
@@ -131,18 +131,36 @@ class ItemRepository @Inject constructor(
             Log.e("Item Repository", "Error adding reward item", e)
         }
     }
+    fun getRewardItems(): Flow<List<MarketItem>> {
+        return db.collection(REWARDS_COLLECTION)
+            .snapshots()
+            .map {
+                it.documents.map { document ->
+                    document.toObject<MarketItem>() ?: MarketItem()
+                }
+            }
+    }
     suspend fun updateInventoryItem(marketItem: InventoryItem) {
         val currentUser = auth.currentUser
         val uid = currentUser!!.uid
 
         val inventoryDocumentRef = getInventoryDocumentRef(uid, marketItem.item.id.toString())
 
-        val updatedData = hashMapOf(
-            "item" to db.collection(MARKET_COLLECTION).document(marketItem.item.id.toString()),
-            "placed" to marketItem.placed,
-            "offsetX" to marketItem.offsetX,
-            "offsetY" to marketItem.offsetY,
-        )
+        val updatedData = if (marketItem.item.id >= 1000) {
+            hashMapOf(
+                "item" to db.collection(REWARDS_COLLECTION).document(marketItem.item.id.toString()),
+                "placed" to marketItem.placed,
+                "offsetX" to marketItem.offsetX,
+                "offsetY" to marketItem.offsetY,
+            )
+        } else {
+            hashMapOf(
+                "item" to db.collection(MARKET_COLLECTION).document(marketItem.item.id.toString()),
+                "placed" to marketItem.placed,
+                "offsetX" to marketItem.offsetX,
+                "offsetY" to marketItem.offsetY,
+            )
+        }
 
         try {
             inventoryDocumentRef

--- a/app/src/main/java/com/github/k409/fitflow/data/ItemRepository.kt
+++ b/app/src/main/java/com/github/k409/fitflow/data/ItemRepository.kt
@@ -115,7 +115,7 @@ class ItemRepository @Inject constructor(
         try {
             val itemReference = db.collection(REWARDS_COLLECTION).whereEqualTo("id", userLevel).get().await().documents.first().reference
 
-            //Log.d("ItemRepository", "Reward item reference: $itemReference")
+            // Log.d("ItemRepository", "Reward item reference: $itemReference")
 
             val inventoryDocumentRef = getInventoryDocumentRef(uid, itemReference.id)
 

--- a/app/src/main/java/com/github/k409/fitflow/data/UserRepository.kt
+++ b/app/src/main/java/com/github/k409/fitflow/data/UserRepository.kt
@@ -93,8 +93,7 @@ class UserRepository @Inject constructor(
                             "hasLeveledUp" to true,
                         ),
                     ).await()
-            }
-            else {
+            } else {
                 userDocRef
                     .update(
                         mapOf(

--- a/app/src/main/java/com/github/k409/fitflow/data/UserRepository.kt
+++ b/app/src/main/java/com/github/k409/fitflow/data/UserRepository.kt
@@ -3,6 +3,7 @@ package com.github.k409.fitflow.data
 import android.util.Log
 import com.github.k409.fitflow.model.User
 import com.github.k409.fitflow.model.toUser
+import com.github.k409.fitflow.ui.screen.level.levels
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.firestore.FieldValue
@@ -78,14 +79,30 @@ class UserRepository @Inject constructor(
     ) {
         val uid = auth.currentUser!!.uid
 
+        val userDocRef = getUserDocumentReference(uid)
+        val user = userDocRef.get().await().toObject<User>() ?: return
+
         try {
-            getUserDocumentReference(uid)
-                .update(
-                    mapOf(
-                        "points" to FieldValue.increment(coins),
-                        "xp" to FieldValue.increment(xp),
-                    ),
-                ).await()
+            // check if user leveled up
+            if (levels.any { user.xp + xp >= it.maxXP && user.xp < it.maxXP }) {
+                userDocRef
+                    .update(
+                        mapOf(
+                            "points" to FieldValue.increment(coins),
+                            "xp" to FieldValue.increment(xp),
+                            "hasLeveledUp" to true,
+                        ),
+                    ).await()
+            }
+            else {
+                userDocRef
+                    .update(
+                        mapOf(
+                            "points" to FieldValue.increment(coins),
+                            "xp" to FieldValue.increment(xp),
+                        ),
+                    ).await()
+            }
         } catch (e: Exception) {
             Log.e("User Repository", "Error updating user coins and xp")
         }
@@ -104,6 +121,18 @@ class UserRepository @Inject constructor(
         }
     }
 
+    suspend fun updateUserField(field: String, value: Any) {
+        val uid = auth.currentUser?.uid ?: return
+
+        try {
+            getUserDocumentReference(uid)
+                .update(field, value)
+                .await()
+        } catch (e: Exception) {
+            Log.e("User Repository", "Error updating user field")
+            Log.e("User Repository", e.toString())
+        }
+    }
     fun getAllUserProfiles(): Flow<List<User>> = callbackFlow {
         val listener = db.collection(USERS_COLLECTION)
             .addSnapshotListener { snapshot, e ->

--- a/app/src/main/java/com/github/k409/fitflow/model/User.kt
+++ b/app/src/main/java/com/github/k409/fitflow/model/User.kt
@@ -16,6 +16,7 @@ data class User(
     var fitnessLevel: String = "",
     var fcmToken: String = "",
     var rank: Int = 0,
+    var hasLeveledUp: Boolean = false,
 )
 
 fun FirebaseUser.toUser(): User {

--- a/app/src/main/java/com/github/k409/fitflow/ui/FitFlowApp.kt
+++ b/app/src/main/java/com/github/k409/fitflow/ui/FitFlowApp.kt
@@ -89,6 +89,7 @@ fun FitFlowApp(
     val startDestination = when {
         user.uid.isEmpty() -> NavRoutes.Login.route
         !user.isProfileComplete() -> NavRoutes.ProfileCreation.route
+        user.hasLeveledUp -> NavRoutes.LevelUp.route
         else -> NavRoutes.Aquarium.route
     }
 
@@ -183,7 +184,7 @@ private fun UpdateTopAndBottomBarVisibility(
     topBarState: MutableState<Boolean>,
 ) {
     when (currentScreen) {
-        NavRoutes.Login, NavRoutes.Default -> {
+        NavRoutes.Login, NavRoutes.Default, NavRoutes.LevelUp -> {
             bottomBarState.value = false
             topBarState.value = false
         }

--- a/app/src/main/java/com/github/k409/fitflow/ui/common/item/ItemCard.kt
+++ b/app/src/main/java/com/github/k409/fitflow/ui/common/item/ItemCard.kt
@@ -105,6 +105,21 @@ fun InventoryItemCard(
 }
 
 @Composable
+fun InventoryItemCardWithoutButtons(
+    modifier: Modifier,
+    imageDownloadUrl: String,
+    name: String,
+    description: String,
+) {
+    InventoryItemCardWrapper(
+        modifier = modifier,
+        imageDownloadUrl = imageDownloadUrl,
+        name = name,
+        description = description,
+    ) {
+    }
+}
+@Composable
 fun InventoryItemCardGooglePay(
     modifier: Modifier,
     imageDownloadUrl: String,

--- a/app/src/main/java/com/github/k409/fitflow/ui/common/item/ItemCard.kt
+++ b/app/src/main/java/com/github/k409/fitflow/ui/common/item/ItemCard.kt
@@ -119,6 +119,7 @@ fun InventoryItemCardWithoutButtons(
     ) {
     }
 }
+
 @Composable
 fun InventoryItemCardGooglePay(
     modifier: Modifier,

--- a/app/src/main/java/com/github/k409/fitflow/ui/navigation/FitFlowNavGraph.kt
+++ b/app/src/main/java/com/github/k409/fitflow/ui/navigation/FitFlowNavGraph.kt
@@ -14,6 +14,7 @@ import com.github.k409.fitflow.ui.screen.hydration.HydrationScreen
 import com.github.k409.fitflow.ui.screen.inventory.InventoryScreen
 import com.github.k409.fitflow.ui.screen.leaderboard.GlobalLeaderboardScreen
 import com.github.k409.fitflow.ui.screen.level.LevelScreen
+import com.github.k409.fitflow.ui.screen.level.LevelUpScreen
 import com.github.k409.fitflow.ui.screen.login.LoginScreen
 import com.github.k409.fitflow.ui.screen.market.MarketScreen
 import com.github.k409.fitflow.ui.screen.profile.ProfileCreationScreen
@@ -85,6 +86,10 @@ fun FitFlowNavGraph(
 
         composable(NavRoutes.You.route) {
             YouScreen()
+        }
+
+        composable(NavRoutes.LevelUp.route) {
+            LevelUpScreen()
         }
     }
 }

--- a/app/src/main/java/com/github/k409/fitflow/ui/navigation/NavRoutes.kt
+++ b/app/src/main/java/com/github/k409/fitflow/ui/navigation/NavRoutes.kt
@@ -41,6 +41,7 @@ sealed class NavRoutes(
             Levels,
             GlobalLeaderboard,
             You,
+            LevelUp,
         )
         val bottomNavBarItems =
             listOf(Aquarium, Activity, Hydration, Goals, Marketplace, You)
@@ -92,4 +93,6 @@ sealed class NavRoutes(
     data object GlobalLeaderboard : NavRoutes("globalLeaderboard", R.string.global, Icons.Outlined.Leaderboard, R.drawable.leaderboard_48)
 
     data object GoalCreation : NavRoutes("goalCreation", R.string.goal_creation, Icons.Outlined.Add)
+
+    data object LevelUp : NavRoutes("levelUp", R.string.levels, Icons.Outlined.LocalPlay)
 }

--- a/app/src/main/java/com/github/k409/fitflow/ui/screen/level/LevelUpScreen.kt
+++ b/app/src/main/java/com/github/k409/fitflow/ui/screen/level/LevelUpScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.github.k409.fitflow.R
@@ -60,7 +60,7 @@ private fun LevelUpScreenContent(viewModel: LevelUpViewModel, uiState: LevelUpUi
     val coroutineScope = rememberCoroutineScope()
 
     // unlike market items, reward items have document numeration starting from 1000
-    val reward = uiState.rewards.first { it.id == level.id + 1000 }
+    val reward = uiState.rewards.firstOrNull { it.id == level.id + 1000 }
 
     val colors = MaterialTheme.colorScheme
     val background = Brush.linearGradient(
@@ -79,10 +79,10 @@ private fun LevelUpScreenContent(viewModel: LevelUpViewModel, uiState: LevelUpUi
         ) {
             Text(
                 text = stringResource(R.string.congratulations_you_have_leveled_up_to, level.name),
-                fontWeight = FontWeight.Bold,
                 style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(16.dp),
+                textAlign = TextAlign.Center,
             )
-            // show badge
             Icon(
                 painter = painterResource(id = level.icon),
                 contentDescription = "Level badge",
@@ -101,12 +101,14 @@ private fun LevelUpScreenContent(viewModel: LevelUpViewModel, uiState: LevelUpUi
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 items(1) {
-                    InventoryItemCardWithoutButtons(
-                        modifier = Modifier,
-                        imageDownloadUrl = reward.phases?.get("Regular") ?: reward.image,
-                        name = reward.title,
-                        description = reward.description,
-                    )
+                    if (reward != null) {
+                        InventoryItemCardWithoutButtons(
+                            modifier = Modifier,
+                            imageDownloadUrl = reward.phases?.get("Regular") ?: reward.image,
+                            name = reward.title,
+                            description = reward.description,
+                        )
+                    }
                     Button(
                         modifier = Modifier
                             .fillMaxWidth()

--- a/app/src/main/java/com/github/k409/fitflow/ui/screen/level/LevelUpScreen.kt
+++ b/app/src/main/java/com/github/k409/fitflow/ui/screen/level/LevelUpScreen.kt
@@ -1,0 +1,74 @@
+package com.github.k409.fitflow.ui.screen.level
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.github.k409.fitflow.ui.common.FitFlowCircularProgressIndicator
+import kotlinx.coroutines.launch
+
+@Composable
+fun LevelUpScreen(
+    viewModel: LevelViewModel = hiltViewModel(),
+    ) {
+    val uiState by viewModel.levelUiState.collectAsState()
+
+    when (uiState) {
+        is LevelUiState.Loading -> {
+            FitFlowCircularProgressIndicator()
+        }
+
+        is LevelUiState.Success -> {
+            LevelUpScreenContent(viewModel = viewModel, uiState = uiState as LevelUiState.Success)
+        }
+    }
+}
+@SuppressLint("CoroutineCreationDuringComposition")
+@Composable
+private fun LevelUpScreenContent(viewModel: LevelViewModel, uiState: LevelUiState.Success) {
+    val clicked = remember { mutableStateOf(false) }
+    val level = levels.first { it.minXP <= uiState.user.xp && it.maxXP >= uiState.user.xp }
+    val coroutineScope = rememberCoroutineScope()
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Text(
+            text = "Congratulations! You have reached level ${level.id}!",
+        )
+        Row(
+            modifier = Modifier.align(Alignment.BottomCenter)
+        ) {
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = {
+                    clicked.value = true
+                }
+            ) {
+                Text(
+                    text = "Awesome!",
+                )
+            }
+        }
+    }
+
+    if (clicked.value) {
+        clicked.value = false
+
+        coroutineScope.launch {
+            //Log.d("LevelUpScreenContent", "Adding reward item to user inventory")
+            viewModel.updateUserField("hasLeveledUp", false)
+            viewModel.addRewardItemToUserInventory(level.id)
+        }
+    }
+}

--- a/app/src/main/java/com/github/k409/fitflow/ui/screen/level/LevelUpScreen.kt
+++ b/app/src/main/java/com/github/k409/fitflow/ui/screen/level/LevelUpScreen.kt
@@ -1,11 +1,20 @@
 package com.github.k409.fitflow.ui.screen.level
 
 import android.annotation.SuppressLint
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -15,53 +24,107 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.github.k409.fitflow.R
 import com.github.k409.fitflow.ui.common.FitFlowCircularProgressIndicator
+import com.github.k409.fitflow.ui.common.item.InventoryItemCardWithoutButtons
 import kotlinx.coroutines.launch
 
 @Composable
 fun LevelUpScreen(
-    viewModel: LevelViewModel = hiltViewModel(),
+    viewModel: LevelUpViewModel = hiltViewModel(),
     ) {
-    val uiState by viewModel.levelUiState.collectAsState()
+    val uiState by viewModel.levelUpUiState.collectAsState()
 
     when (uiState) {
-        is LevelUiState.Loading -> {
+        is LevelUpUiState.Loading -> {
             FitFlowCircularProgressIndicator()
         }
 
-        is LevelUiState.Success -> {
-            LevelUpScreenContent(viewModel = viewModel, uiState = uiState as LevelUiState.Success)
+        is LevelUpUiState.Success -> {
+            LevelUpScreenContent(viewModel = viewModel, uiState = uiState as LevelUpUiState.Success)
         }
     }
 }
 @SuppressLint("CoroutineCreationDuringComposition")
 @Composable
-private fun LevelUpScreenContent(viewModel: LevelViewModel, uiState: LevelUiState.Success) {
+private fun LevelUpScreenContent(viewModel: LevelUpViewModel, uiState: LevelUpUiState.Success) {
     val clicked = remember { mutableStateOf(false) }
     val level = levels.first { it.minXP <= uiState.user.xp && it.maxXP >= uiState.user.xp }
     val coroutineScope = rememberCoroutineScope()
 
-    Box(modifier = Modifier.fillMaxSize()) {
-        Text(
-            text = "Congratulations! You have reached level ${level.id}!",
-        )
-        Row(
-            modifier = Modifier.align(Alignment.BottomCenter)
+    // unlike market items, reward items have document numeration starting from 1000
+    val reward = uiState.rewards.first { it.id == level.id + 1000 }
+
+    val colors = MaterialTheme.colorScheme
+    val background = Brush.linearGradient(
+        colors = listOf(
+            colors.tertiaryContainer,
+            colors.onTertiaryContainer,
+        ),
+    )
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(background),
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Button(
-                modifier = Modifier.fillMaxWidth(),
-                onClick = {
-                    clicked.value = true
-                }
+            Text(
+                text = stringResource(R.string.congratulations_you_have_leveled_up_to, level.name),
+                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.titleMedium,
+            )
+            // show badge
+            Icon(
+                painter = painterResource(id = level.icon),
+                contentDescription = "Level badge",
+                tint = Color.Unspecified,
+                modifier = Modifier
+                    .size(120.dp),
+            )
+            Spacer(modifier = Modifier.padding(4.dp))
+            Text(
+                text = stringResource(R.string.you_have_unlocked_the_following_reward),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Spacer(modifier = Modifier.padding(4.dp))
+            LazyColumn(
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                Text(
-                    text = "Awesome!",
-                )
+                items(1) {
+                    InventoryItemCardWithoutButtons(
+                        modifier = Modifier,
+                        imageDownloadUrl = reward.phases?.get("Regular") ?: reward.image,
+                        name = reward.title,
+                        description = reward.description,
+                    )
+                    Button(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(8.dp),
+                        onClick = {
+                            clicked.value = true
+                        }
+                    ) {
+                        Text(
+                            text = stringResource(R.string.awesome),
+                            style = MaterialTheme.typography.labelLarge,
+                        )
+                    }
+                }
             }
         }
-    }
 
+    }
     if (clicked.value) {
         clicked.value = false
 

--- a/app/src/main/java/com/github/k409/fitflow/ui/screen/level/LevelUpScreen.kt
+++ b/app/src/main/java/com/github/k409/fitflow/ui/screen/level/LevelUpScreen.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun LevelUpScreen(
     viewModel: LevelUpViewModel = hiltViewModel(),
-    ) {
+) {
     val uiState by viewModel.levelUpUiState.collectAsState()
 
     when (uiState) {
@@ -52,6 +52,7 @@ fun LevelUpScreen(
         }
     }
 }
+
 @SuppressLint("CoroutineCreationDuringComposition")
 @Composable
 private fun LevelUpScreenContent(viewModel: LevelUpViewModel, uiState: LevelUpUiState.Success) {
@@ -75,7 +76,7 @@ private fun LevelUpScreenContent(viewModel: LevelUpViewModel, uiState: LevelUpUi
             .background(background),
     ) {
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
                 text = stringResource(R.string.congratulations_you_have_leveled_up_to, level.name),
@@ -115,7 +116,7 @@ private fun LevelUpScreenContent(viewModel: LevelUpViewModel, uiState: LevelUpUi
                             .padding(8.dp),
                         onClick = {
                             clicked.value = true
-                        }
+                        },
                     ) {
                         Text(
                             text = stringResource(R.string.awesome),
@@ -125,13 +126,12 @@ private fun LevelUpScreenContent(viewModel: LevelUpViewModel, uiState: LevelUpUi
                 }
             }
         }
-
     }
     if (clicked.value) {
         clicked.value = false
 
         coroutineScope.launch {
-            //Log.d("LevelUpScreenContent", "Adding reward item to user inventory")
+            // Log.d("LevelUpScreenContent", "Adding reward item to user inventory")
             viewModel.updateUserField("hasLeveledUp", false)
             viewModel.addRewardItemToUserInventory(level.id)
         }

--- a/app/src/main/java/com/github/k409/fitflow/ui/screen/level/LevelUpViewModel.kt
+++ b/app/src/main/java/com/github/k409/fitflow/ui/screen/level/LevelUpViewModel.kt
@@ -21,24 +21,24 @@ class LevelUpViewModel @Inject constructor(
     val levelUpUiState: StateFlow<LevelUpUiState> = combine(
         userRepository.currentUser,
         itemRepository.getRewardItems(),
-        ) { user, rewards ->
-            LevelUpUiState.Success(
-                user = user,
-                rewards = rewards,
-            )
-
-        }.stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = LevelUpUiState.Loading,
+    ) { user, rewards ->
+        LevelUpUiState.Success(
+            user = user,
+            rewards = rewards,
         )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = LevelUpUiState.Loading,
+    )
 
     suspend fun updateUserField(field: String, value: Any) {
         userRepository.updateUserField(field, value)
     }
+
     // User level needs to be incremented by 1000, because reward numeration starts from 1000
-    suspend fun addRewardItemToUserInventory(userLevel : Int) {
-        itemRepository.addRewardItemToUserInventory(userLevel + 1000 )
+    suspend fun addRewardItemToUserInventory(userLevel: Int) {
+        itemRepository.addRewardItemToUserInventory(userLevel + 1000)
     }
 }
 

--- a/app/src/main/java/com/github/k409/fitflow/ui/screen/level/LevelUpViewModel.kt
+++ b/app/src/main/java/com/github/k409/fitflow/ui/screen/level/LevelUpViewModel.kt
@@ -1,0 +1,51 @@
+package com.github.k409.fitflow.ui.screen.level
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.k409.fitflow.data.ItemRepository
+import com.github.k409.fitflow.data.UserRepository
+import com.github.k409.fitflow.model.MarketItem
+import com.github.k409.fitflow.model.User
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class LevelUpViewModel @Inject constructor(
+    private val userRepository: UserRepository,
+    private val itemRepository: ItemRepository,
+) : ViewModel() {
+    val levelUpUiState: StateFlow<LevelUpUiState> = combine(
+        userRepository.currentUser,
+        itemRepository.getRewardItems(),
+        ) { user, rewards ->
+            LevelUpUiState.Success(
+                user = user,
+                rewards = rewards,
+            )
+
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = LevelUpUiState.Loading,
+        )
+
+    suspend fun updateUserField(field: String, value: Any) {
+        userRepository.updateUserField(field, value)
+    }
+    // User level needs to be incremented by 1000, because reward numeration starts from 1000
+    suspend fun addRewardItemToUserInventory(userLevel : Int) {
+        itemRepository.addRewardItemToUserInventory(userLevel + 1000 )
+    }
+}
+
+sealed interface LevelUpUiState {
+    data object Loading : LevelUpUiState
+    data class Success(
+        val user: User,
+        val rewards: List<MarketItem>,
+    ) : LevelUpUiState
+}

--- a/app/src/main/java/com/github/k409/fitflow/ui/screen/level/LevelViewModel.kt
+++ b/app/src/main/java/com/github/k409/fitflow/ui/screen/level/LevelViewModel.kt
@@ -2,7 +2,6 @@ package com.github.k409.fitflow.ui.screen.level
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.github.k409.fitflow.data.ItemRepository
 import com.github.k409.fitflow.data.UserRepository
 import com.github.k409.fitflow.model.User
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -14,8 +13,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LevelViewModel @Inject constructor(
-    private val userRepository: UserRepository,
-    private val itemRepository: ItemRepository,
+    userRepository: UserRepository,
 ) : ViewModel() {
     val levelUiState: StateFlow<LevelUiState> =
         userRepository.currentUser.map { user ->
@@ -27,13 +25,6 @@ class LevelViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(5_000),
             initialValue = LevelUiState.Loading,
         )
-
-    suspend fun updateUserField(field: String, value: Any) {
-        userRepository.updateUserField(field, value)
-    }
-    suspend fun addRewardItemToUserInventory(userLevel : Int) {
-        itemRepository.addRewardItemToUserInventory(userLevel)
-    }
 }
 
 sealed interface LevelUiState {

--- a/app/src/main/java/com/github/k409/fitflow/ui/screen/level/LevelViewModel.kt
+++ b/app/src/main/java/com/github/k409/fitflow/ui/screen/level/LevelViewModel.kt
@@ -2,6 +2,7 @@ package com.github.k409.fitflow.ui.screen.level
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.github.k409.fitflow.data.ItemRepository
 import com.github.k409.fitflow.data.UserRepository
 import com.github.k409.fitflow.model.User
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -13,7 +14,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LevelViewModel @Inject constructor(
-    userRepository: UserRepository,
+    private val userRepository: UserRepository,
+    private val itemRepository: ItemRepository,
 ) : ViewModel() {
     val levelUiState: StateFlow<LevelUiState> =
         userRepository.currentUser.map { user ->
@@ -25,6 +27,13 @@ class LevelViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(5_000),
             initialValue = LevelUiState.Loading,
         )
+
+    suspend fun updateUserField(field: String, value: Any) {
+        userRepository.updateUserField(field, value)
+    }
+    suspend fun addRewardItemToUserInventory(userLevel : Int) {
+        itemRepository.addRewardItemToUserInventory(userLevel)
+    }
 }
 
 sealed interface LevelUiState {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -132,4 +132,7 @@
     <string name="updating_goals_and_steps_data">Updating goals and steps data</string>
     <string name="walking_goal_progress">Walking Goal Progress</string>
     <string name="you_have_walked_out_of_steps_today">You have walked %1$s out of %2$s steps today.</string>
+    <string name="congratulations_you_have_leveled_up_to">Congratulations! You have leveled up to %1$s!</string>
+    <string name="you_have_unlocked_the_following_reward">You have unlocked the following reward:</string>
+    <string name="awesome">Awesome!</string>
 </resources>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Implemented level up rewards and level up screen
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Added rewards for each level (except level 1)
- [x] Implemented level up screen that pops up when user has enough xp to level up
- [x] Moved Cardio Crab and Deeproot Coral from Marketplace to Rewards

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Reward documents in database are numbered from 1000 in case to avoid conflicts with market items (which are numbered from 0-999)
- Users are checked for level up when they gain xp
- Background colors are dependant on currently selected theme

Screenshots:
<img src="https://github.com/PVP-K409/fit-flow/assets/127019248/d3be930d-d855-4133-b00b-538581878abb" width=50% height=50%>
<img src="https://github.com/PVP-K409/fit-flow/assets/127019248/9f7fdcef-b761-4414-9408-10da87941e1c" width=50% height=50%>
